### PR TITLE
Fixes metamsk signing from js playground

### DIFF
--- a/packages/trnsp-custom/src/components/TxExternalSigned.tsx
+++ b/packages/trnsp-custom/src/components/TxExternalSigned.tsx
@@ -6,7 +6,9 @@ import type { BN } from '@polkadot/util';
 
 import React, { useCallback, useEffect, useState } from 'react';
 
+import { SubmittableResult } from '@polkadot/api';
 import { Button, ErrorBoundary, Modal, Output, styled } from '@polkadot/react-components';
+import { QueueTxStatus } from '@polkadot/react-components/Status/types';
 import { useApi, useQueue, useToggle } from '@polkadot/react-hooks';
 import Address from '@polkadot/react-signer/Address';
 import Tip from '@polkadot/react-signer/Tip';
@@ -90,10 +92,20 @@ function TxSigned ({ className, currentItem, requestAddress }: Props): React.Rea
           const signedExtrinsic = await signWithEthereumWallet(api, senderInfo.signAddress, currentItem.extrinsic, { tip });
 
           queueSetTxStatus(currentItem.id, 'sending');
+
           if (signedExtrinsic.send) {
             const unsubscribe: () => void = await signedExtrinsic.send(handleTxResults('signAndSend', queueSetTxStatus, currentItem, () => unsubscribe()));
           } else {
-            await api.rpc.author.submitAndWatchExtrinsic(currentItem.extrinsic);
+            const unsubscribe = await api.rpc.author.submitAndWatchExtrinsic(currentItem.extrinsic, (res): void => {
+              const status = res.type.toLowerCase() as QueueTxStatus;
+
+              queueSetTxStatus(currentItem.id, status, res);
+
+              if (currentItem?.txUpdateCb) {
+                currentItem?.txUpdateCb(res as unknown as SubmittableResult);
+                unsubscribe();
+              }
+            });
           }
         } catch (error) {
           const { code, message } = error as {code: number, message: string};

--- a/packages/trnsp-custom/src/components/TxExternalSigned.tsx
+++ b/packages/trnsp-custom/src/components/TxExternalSigned.tsx
@@ -90,7 +90,11 @@ function TxSigned ({ className, currentItem, requestAddress }: Props): React.Rea
           const signedExtrinsic = await signWithEthereumWallet(api, senderInfo.signAddress, currentItem.extrinsic, { tip });
 
           queueSetTxStatus(currentItem.id, 'sending');
-          const unsubscribe: () => void = await signedExtrinsic.send(handleTxResults('signAndSend', queueSetTxStatus, currentItem, () => unsubscribe()));
+          if (signedExtrinsic.send) {
+            const unsubscribe: () => void = await signedExtrinsic.send(handleTxResults('signAndSend', queueSetTxStatus, currentItem, () => unsubscribe()));
+          } else {
+            await api.rpc.author.submitAndWatchExtrinsic(currentItem.extrinsic);
+          }
         } catch (error) {
           const { code, message } = error as {code: number, message: string};
 


### PR DESCRIPTION
## Summary

Fixes cannot sign extrinsic via metamask on js console on portal.
Need a little update on txQueue so that the tx doesn't show loading image..
