### PR TITLE
[Fix] Fix build error due to latest commit

### DIFF
--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2023 @polkadot/react-api authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import '@therootnetwork/api-types';
+// import '@therootnetwork/api-types';
 
 import type { LinkOption } from '@polkadot/apps-config/endpoints/types';
 import type { InjectedExtension } from '@polkadot/extension-inject/types';


### PR DESCRIPTION
## Summary

Remove the types override from `@therootnetwork/api-types` since it's generated by a newer `@polkadot/api` version

## Checklist

- [x] Add description
